### PR TITLE
[BUG] Use the from sha-1 parameter really as from with git, not as to.

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -68,7 +68,7 @@ class BaseCommand extends Command
 		if($to) {
 			$rangeArg = escapeshellarg("$from..$to");
 		} else {
-			$rangeArg = escapeshellarg("$from");
+			$rangeArg = escapeshellarg("$from..");
 		}	
 
 		return array($lockFrom, $lockTo, $rangeArg);


### PR DESCRIPTION
The proper usage to use the from sha-1 as starting point is to add '..' after the first sha-1.
Just using the sha-1 without the dots will use the sha-1 as to.