### PR TITLE
[FEATURE] Ignore packages which do not have a source entry.

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -84,15 +84,17 @@ class BaseCommand extends Command
 
 		$output = array();
 
-		foreach ($lock['packages'] as $package) {
-			switch ($package['source']['type']) {
-				case 'git':
-					$output[$package['name']] = $package['source'];
-					break;
-				default:
-					throw new \LogicException("Bad package source type: '" . $package['source']['type'] . "'");
-			}
-		}
+        foreach ($lock['packages'] as $package) {
+            if (isset($package['source'])) {
+                switch ($package['source']['type']) {
+                    case 'git':
+                        $output[$package['name']] = $package['source'];
+                        break;
+                    default:
+                        throw new \LogicException("Bad package source type: '" . $package['source']['type'] . "'");
+                }
+            }
+        }
 
 		return $output;
 	}


### PR DESCRIPTION
Some packages do not have a source entry at all. This will stop the further processing of the composer.lock file.